### PR TITLE
Adds travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: node_js
+node_js:
+- 0.8
+- 0.9
+- 0.10
+script: "grunt test"


### PR DESCRIPTION
I'm not sure which node platforms you want to target, but travis is pretty easy to setup. If you go to https://travis-ci.org/ you can sign in with github and enable it for this repository; I've added a simple travis configuration file that should execute tests against the last 3 major node releases, feel free to modify with whatever you think is ideal :)
