### PR TITLE
Update to use new //# sourceMappingURL syntax

### DIFF
--- a/tasks/concat_sourcemap.js
+++ b/tasks/concat_sourcemap.js
@@ -88,7 +88,7 @@ module.exports = function(grunt) {
       if (/\.css$/.test(f.dest)) {
         sourceNode.add('/*# sourceMappingURL=' + mapfilepath + ' */');
       } else {
-        sourceNode.add('//@ sourceMappingURL=' + mapfilepath);
+        sourceNode.add('//# sourceMappingURL=' + mapfilepath);
       }
 
       var code_map = sourceNode.toStringWithSourceMap({

--- a/test/expected/default_options.js
+++ b/test/expected/default_options.js
@@ -7,4 +7,4 @@
 
 "file 3 - line 1";
 
-//@ sourceMappingURL=default_options.js.map
+//# sourceMappingURL=default_options.js.map

--- a/test/expected/options_with_sourceRoot.js
+++ b/test/expected/options_with_sourceRoot.js
@@ -7,4 +7,4 @@
 
 "file 3 - line 1";
 
-//@ sourceMappingURL=options_with_sourceRoot.js.map
+//# sourceMappingURL=options_with_sourceRoot.js.map

--- a/test/expected/options_with_sourcesContent.js
+++ b/test/expected/options_with_sourcesContent.js
@@ -7,4 +7,4 @@
 
 "file 3 - line 1";
 
-//@ sourceMappingURL=options_with_sourcesContent.js.map
+//# sourceMappingURL=options_with_sourcesContent.js.map


### PR DESCRIPTION
We were seeing an error in IE9 because grunt-concat-sourcemap was generating the //@ syntax for sourcemaps instead of the newer //# syntax.

This pull request changes it to //# instead.
This matches the syntax that grunt-contrib-uglify uses as well.

For more information see:
https://groups.google.com/forum/#!topic/mozilla.dev.js-sourcemap/4uo7Z5nTfUY
https://github.com/gruntjs/grunt-contrib-uglify/commit/0066be8645b97740bc74f58f904943198841ffd9
