### PR TITLE
added process hook to options

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -103,6 +103,20 @@ module.exports = function(grunt) {
           ],
         },
       },
+      options_with_process: {
+        options: {
+          process: function(src) {
+            return '(function(){' + src + '})();';
+          }
+        },
+        files: {
+          'tmp/options_with_process.js': [
+            'test/fixtures/file1.js',
+            'test/fixtures/file2.js',
+            'test/fixtures/file3.js'
+          ],
+        },
+      },
       with_coffee: {
         options: {
         },

--- a/README.md
+++ b/README.md
@@ -62,6 +62,14 @@ Default value: `false`
 
 An optional flag that tells the source map generator whether or not to include all original sources in the map. `sourcesContent` is an array of contents of the original source files. This is useful if you don't want to have to upload original src files to the webserver that will be serving the sourcemap.
 
+#### options.process
+
+Type: `Function`
+Default value: `undefined`
+
+* `undefined` - Do not apply any processing to the source files
+* `function(src, filepath)` - Process source files using the given function, called once for each file. The returned value will be used as source code.
+
 ### Usage Examples
 
 #### Default Options
@@ -136,6 +144,25 @@ You would see a resulting `dest/default_options.js.map` that included `sourcesCo
       "\"file b - line 1\";\n"
     ]
   }
+```
+
+#### Using `process`
+
+```js
+grunt.initConfig({
+  concat_sourcemap: {
+    options: {
+      process: function(src, filepath) {
+        return '(function(){' + src + '})();';
+      }
+    },
+    target: {
+      files: {
+        'dest/closureWrapped.js': ['src/a.js', 'src/b.js']
+      }
+    }
+  }
+})
 ```
 
 Contributing

--- a/package.json
+++ b/package.json
@@ -44,6 +44,6 @@
     "sourcemap"
   ],
   "dependencies": {
-    "source-map": "~0.1.31"
+    "source-map": "0.1.31"
   }
 }

--- a/tasks/concat_sourcemap.js
+++ b/tasks/concat_sourcemap.js
@@ -24,7 +24,8 @@ module.exports = function(grunt) {
     var options = this.options({
       separator: grunt.util.linefeed,
       sourceRoot: '',
-      sourcesContent: false
+      sourcesContent: false,
+      process: undefined
     });
 
     // Iterate over all src-dest file pairs.
@@ -48,6 +49,11 @@ module.exports = function(grunt) {
         // Read file source.
         var filename = filepaths[i];
         var src = grunt.file.read(filename);
+
+        if(typeof options.process === 'function') {
+          src = options.process(src, filename);
+        }
+
         var childNodeChunks = src.split('\n');
         for (j = 0, m = childNodeChunks.length - 1; j < m; j++) {
           childNodeChunks[j] += '\n';

--- a/test/concat_sourcemap_test.js
+++ b/test/concat_sourcemap_test.js
@@ -46,6 +46,15 @@ exports.concat_sourcemap = {
 
     test.done();
   },
+  options_with_process: function(test) {
+    test.expect(1);
+
+    var actual = grunt.file.read('tmp/options_with_process.js');
+    var expected = grunt.file.read('test/expected/options_with_process.js');
+    test.equal(actual, expected, 'should use process function to modify concatenated file');
+
+    test.done();
+  },
   with_coffee: function(test) {
     test.expect(1);
 

--- a/test/expected/options_with_process.js
+++ b/test/expected/options_with_process.js
@@ -1,0 +1,10 @@
+(function(){"file 1 - line 1";
+"file 1 - line 2";
+"file 1 - line 3";
+})();
+(function(){"file 2 - line 1";
+"file 2 - line 2";
+})();
+(function(){"file 3 - line 1";
+})();
+//# sourceMappingURL=options_with_process.js.map


### PR DESCRIPTION
a new `process` option allows to process each file before it gets concatenated.
unit tests and readme is also adjusted.
