### PR TITLE
Prevent multiple runs/target from impacting each others

### DIFF
--- a/tasks/concat_sourcemap.js
+++ b/tasks/concat_sourcemap.js
@@ -16,10 +16,10 @@ module.exports = function(grunt) {
   var SourceMapGenerator = require('source-map').SourceMapGenerator;
   var SourceNode = require('source-map').SourceNode;
 
-  // source map file of input
-  var sourceMaps = [];
-
   grunt.registerMultiTask('concat_sourcemap', 'Concatenate files and generate a source map.', function() {
+    // source map file of input
+    var sourceMaps = [];
+
     // Merge task-specific and/or target-specific options with these defaults.
     var options = this.options({
       separator: grunt.util.linefeed,


### PR DESCRIPTION
Running multiple times the same target can mess up the build if config
changes in between (by listening to the watch event for example).
This should fix those use cases.