### PR TITLE
Prevent unit-test from failing on Windows

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -70,6 +70,7 @@ module.exports = function(grunt) {
     concat_sourcemap: {
       default_options: {
         options: {
+          separator: '\n',
         },
         files: {
           'tmp/default_options.js': [
@@ -81,6 +82,7 @@ module.exports = function(grunt) {
       },
       options_with_sourceRoot: {
         options: {
+          separator: '\n',
           sourceRoot: 'tmp',
         },
         files: {
@@ -93,6 +95,7 @@ module.exports = function(grunt) {
       },
       options_with_sourcesContent: {
         options: {
+          separator: '\n',
           sourcesContent: true,
         },
         files: {
@@ -105,6 +108,7 @@ module.exports = function(grunt) {
       },
       options_with_process: {
         options: {
+          separator: '\n',
           process: function(src) {
             return '(function(){' + src + '})();';
           }
@@ -119,6 +123,7 @@ module.exports = function(grunt) {
       },
       with_coffee: {
         options: {
+          separator: '\n',
         },
         files: {
           'tmp/with_coffee.js': [
@@ -132,6 +137,7 @@ module.exports = function(grunt) {
       },
       with_existing_map: {
         options: {
+          separator: '\n',
         },
         files: {
           'tmp/with_existing_map.js': [
@@ -142,6 +148,7 @@ module.exports = function(grunt) {
       },
       css_files: {
         options: {
+          separator: '\n',
         },
         files: {
           'tmp/css_files.css': [
@@ -152,6 +159,7 @@ module.exports = function(grunt) {
       },
       css_files_with_sass_generated: {
         options: {
+          separator: '\n',
           sourceRoot: '../',
         },
         files: {
@@ -162,6 +170,9 @@ module.exports = function(grunt) {
         },
       },
       file_with_linking: {
+        options: {
+          separator: '\n',
+        },
         files: {
           'tmp/file_with_linking.js': [
             'test/fixtures/file_with_linking1.js',
@@ -170,6 +181,9 @@ module.exports = function(grunt) {
         },
       },
       file_with_old_linking: {
+        options: {
+          separator: '\n',
+        },
         files: {
           'tmp/file_with_old_linking.js': [
             'test/fixtures/file_with_old_linking1.js',


### PR DESCRIPTION
The difference of default linefeed on windows causes unit-test filing. So a `separator` option was added to fix a linefeed in output files.