### PR TITLE
Don't merge original 'data' source mappings

### DIFF
--- a/tasks/concat_sourcemap.js
+++ b/tasks/concat_sourcemap.js
@@ -55,7 +55,7 @@ module.exports = function(grunt) {
           src = options.process(src, filename);
         }
 
-        if (/\/\/[@#]\s+sourceMappingURL=(.+)/.test(src) || /\/\*#\s+sourceMappingURL=([^\s]+)\s+\*\//.test(src)) {
+        if ((/\/\/[@#]\s+sourceMappingURL=(.+)/.test(src) || /\/\*#\s+sourceMappingURL=([^\s]+)\s+\*\//.test(src)) && !/sourceMappingURL=data:/.test(src)) {
           var sourceMappingURL = RegExp.$1;
           var sourceMapPath = path.resolve(path.dirname(filename), sourceMappingURL);
           var sourceMap = JSON.parse(grunt.file.read(sourceMapPath));


### PR DESCRIPTION
Prevent an error that occur when we try to read an original source mapping, and this source mapping is not a file but an inlined data.
