### PR TITLE
fixes case with sourcesContent but no actual source files

### DIFF
--- a/tasks/concat_sourcemap.js
+++ b/tasks/concat_sourcemap.js
@@ -111,8 +111,11 @@ module.exports = function(grunt) {
 
       if(options.sourcesContent) {
         sourceMaps.forEach(function(sourceMap){
-          sourceMap[0].sources.forEach(function(source){
-            generator.setSourceContent(source, grunt.file.read(path.resolve(destDir, source)));
+          var sourceMapConsumer = sourceMap[0];
+          var sourcesContent = sourceMapConsumer.sourcesContent;
+          sourceMapConsumer.sources.forEach(function(source, index){
+            var content = sourcesContent && sourcesContent[index] || grunt.file.read(path.resolve(destDir, source));
+            generator.setSourceContent(source, content);
           });
         });
       }


### PR DESCRIPTION
When you have minified files and source maps with `sourcesContent` property, but no source files, the target source map can still have `sourcesContent` properly populated. 

The current implementation always tries to read the source files and fails when they are missing. This patch uses `sourcesContent` when it's present.
